### PR TITLE
Skip specific IDs

### DIFF
--- a/internal/selfbot.py
+++ b/internal/selfbot.py
@@ -11,10 +11,12 @@ from internal.utils import (
     create_guild_directory,
     create_member_file,
     filter_out_known_ids,
+    filter_out_specific_ids,
     get_account_settings,
     get_bio_fname,
     get_guild_members_fname,
     load_member_ids_from_disk,
+    load_skipped_member_ids_from_disk,
     save_members_dict,
 )
 
@@ -61,6 +63,7 @@ async def on_ready() -> None:
         members = [DummyMember(i, guild) for i in member_ids]
 
     members = filter_out_known_ids(members)
+    members = filter_out_specific_ids(members, load_skipped_member_ids_from_disk())
 
     counter = 0
 

--- a/internal/selfbot.py
+++ b/internal/selfbot.py
@@ -63,7 +63,7 @@ async def on_ready() -> None:
         members = [DummyMember(i, guild) for i in member_ids]
 
     members = filter_out_known_ids(members)
-    members = filter_out_specific_ids(members, load_skipped_member_ids_from_disk())
+    members = filter_out_specific_ids(members, set(load_skipped_member_ids_from_disk()))
 
     counter = 0
 

--- a/internal/selfbot.py
+++ b/internal/selfbot.py
@@ -10,11 +10,11 @@ from internal.utils import (
     Logger,
     create_guild_directory,
     create_member_file,
-    filter_out_known_ids,
     filter_out_specific_ids,
     get_account_settings,
     get_bio_fname,
     get_guild_members_fname,
+    load_known_ids,
     load_member_ids_from_disk,
     load_skipped_member_ids_from_disk,
     save_members_dict,
@@ -62,8 +62,10 @@ async def on_ready() -> None:
         member_ids.update([e.id for e in members])
         members = [DummyMember(i, guild) for i in member_ids]
 
-    members = filter_out_known_ids(members)
-    members = filter_out_specific_ids(members, set(load_skipped_member_ids_from_disk()))
+    members = filter_out_specific_ids(
+        members,
+        set(load_skipped_member_ids_from_disk()).union(load_known_ids()),
+    )
 
     counter = 0
 

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -34,7 +34,7 @@ class DummyMember(NamedTuple):
 
 def filter_out_specific_ids(
     members: list[Member],
-    specific_ids: list[int],
+    specific_ids: set[int],
 ) -> list[Member]:
     skipped_member_ids = frozenset(specific_ids)
     return [e for e in members if e.id not in skipped_member_ids]
@@ -46,7 +46,7 @@ def load_known_ids() -> list[int]:
 
 def filter_out_known_ids(members: list[Member]) -> list[Member]:
     known_member_ids = load_known_ids()
-    return filter_out_specific_ids(members, known_member_ids)
+    return filter_out_specific_ids(members, set(known_member_ids))
 
 
 def chunks(lst: list, n: int) -> Iterator[list]:

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -20,7 +20,8 @@ from internal.constants import (
 from src.environment_utils import find_config_in_environment
 
 DUMMY_ROLE = "@everyone"
-MEMBER_ID_FNAME = "ids.txt"
+DATA_FOLDER_NAME = "data/"
+MEMBER_ID_FNAME = f"{DATA_FOLDER_NAME}ids.txt"
 
 
 class DummyMember(NamedTuple):

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -22,6 +22,7 @@ from src.environment_utils import find_config_in_environment
 DUMMY_ROLE = "@everyone"
 DATA_FOLDER_NAME = "data/"
 MEMBER_ID_FNAME = f"{DATA_FOLDER_NAME}ids.txt"
+SKIPPED_MEMBER_ID_FNAME = f"{DATA_FOLDER_NAME}ids_skipped.txt"
 
 
 class DummyMember(NamedTuple):
@@ -170,6 +171,10 @@ def load_member_ids_from_disk(fname: str = MEMBER_ID_FNAME) -> list[int]:
     except FileNotFoundError:
         member_ids = []
     return member_ids
+
+
+def load_skipped_member_ids_from_disk() -> list[int]:
+    return load_member_ids_from_disk(SKIPPED_MEMBER_ID_FNAME)
 
 
 def save_members_dict(members: list[Member], fname: str) -> None:

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -30,11 +30,17 @@ class DummyMember(NamedTuple):
     avatar: Asset | None = None
 
 
+def filter_out_specific_ids(
+    members: list[Member],
+    specific_ids: list[int],
+) -> list[Member]:
+    skipped_member_ids = frozenset(specific_ids)
+    return [e for e in members if e.id not in skipped_member_ids]
+
+
 def filter_out_known_ids(members: list[Member]) -> list[Member]:
-    known_member_ids = frozenset(
-        [int(s.stem) for s in Path(MEMBER_FOLDER_NAME).glob("*/*.json")],
-    )
-    return [e for e in members if e.id not in known_member_ids]
+    known_member_ids = [int(s.stem) for s in Path(MEMBER_FOLDER_NAME).glob("*/*.json")]
+    return filter_out_specific_ids(members, known_member_ids)
 
 
 def chunks(lst: list, n: int) -> Iterator[list]:

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -40,8 +40,12 @@ def filter_out_specific_ids(
     return [e for e in members if e.id not in skipped_member_ids]
 
 
+def load_known_ids() -> list[int]:
+    return [int(s.stem) for s in Path(MEMBER_FOLDER_NAME).glob("*/*.json")]
+
+
 def filter_out_known_ids(members: list[Member]) -> list[Member]:
-    known_member_ids = [int(s.stem) for s in Path(MEMBER_FOLDER_NAME).glob("*/*.json")]
+    known_member_ids = load_known_ids()
     return filter_out_specific_ids(members, known_member_ids)
 
 


### PR DESCRIPTION
This allows to skip the scraping of data from members whose IDs appear in `data/ids_skipped.txt`.

This is useful for privacy concerns in order to monitor new members without keeping data of old members or tracking them again.